### PR TITLE
Add get_param_keys.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc = include_str!("../examples/simple.rs")]
 //! ```
 use log::{trace, warn};
+use std::collections::hash_map::Keys;
 use std::fmt::Debug;
 use std::marker::Unpin;
 use std::io::{Read, Write};
@@ -566,6 +567,15 @@ impl <W: AsyncWrite + Unpin> Request<W> {
 		}
 
 		Ok(())
+	}
+
+	/// Returns an iterator over the parameter keys.
+	pub fn get_param_keys(&self) -> Option<Keys<'_, String, Vec<u8>>> {
+		if self.params_done {
+			Some(self.params.keys())
+		} else {
+			None
+		}
 	}
 
 	/// Returns the parameter with the given name as a byte vector.

--- a/tests/commons.rs
+++ b/tests/commons.rs
@@ -83,6 +83,13 @@ impl TestCase for TestParamsInOut {
 	}
 
 	async fn processor<W: AsyncWrite + Unpin + Send>(request: Arc<Request<W>>) -> RequestResult {
+		let mut keys: Vec<String> = request.get_param_keys().unwrap().map(|k| k.clone()).collect();
+		keys.sort();
+
+		assert_eq!(keys.len(), 2);
+		assert_eq!(keys[0], "server_port");
+		assert_eq!(keys[1], "test");
+
 		// Check the parameters
 		let sp = request.get_param("SERVER_PORT");
 		assert!(sp.is_some());


### PR DESCRIPTION
Would you consider the following change to allow access to an iterator over the Request parameter keys?

I could not find a way currently to do this but maybe I am missing something.  

Happy to change the name of the method or add more tests.

Thanks!