### PR TITLE
Replace once_cell with std::sync::LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ byteorder = "1"
 tokio = { version = "1", features = ["test-util", "net", "rt-multi-thread"] }
 tokio-test = "0.4"
 async-trait = "0.1"
-once_cell = "1"

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -20,15 +20,14 @@ use tokio::runtime;
 use tokio_fastcgi::Requests;
 use std::{io::{Read, Write}, panic};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, Shutdown, TcpStream};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::sync::mpsc::sync_channel;
-use once_cell::sync::Lazy;
 
 mod commons;
 use crate::commons::*;
 
 /// Global lock to prevent running more than one server via multithreaded tests.
-static GLOBAL_LOCK: Lazy<Mutex<u32>> = Lazy::new(|| { Mutex::default() });
+static GLOBAL_LOCK: LazyLock<Mutex<u32>> = LazyLock::new(|| { Mutex::default() });
 
 /// This is a test fixture that will run a FastCGI server on a free port and
 /// connect to it to run some test cases.


### PR DESCRIPTION
The features of `once_cell` have been merged into `std`, so we can avoid depending on this crate nowadays.