### PR TITLE
Remove async-trait dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ byteorder = "1"
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util", "net", "rt-multi-thread"] }
 tokio-test = "0.4"
-async-trait = "0.1"
 once_cell = "1"

--- a/examples/apiserver.rs
+++ b/examples/apiserver.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, collections::HashMap, io::Read};
 
-use async_trait::async_trait;
 use tokio::{net::{TcpListener, tcp::OwnedWriteHalf}, sync::RwLock};
 use tokio_fastcgi::{Requests, RequestResult, Request};
 
@@ -80,7 +79,6 @@ impl HttpResponse {
 
 /// Request handler trait. All request handlers have to implement this async trait.
 /// The default implementation for every method returns the 405 (Method Not Allowed) error code.
-#[async_trait]
 trait RequestHandler {
 	async fn get(_store: Arc<RwLock<Store>>, _request: &Request<OwnedWriteHalf>, _selector: Option<u32>) -> Result<String, HttpResponse> {
 		Err(HttpResponse::e405())
@@ -115,7 +113,6 @@ impl Store {
 /// Handles the REST API for quotes.
 struct Quotes {}
 
-#[async_trait]
 impl RequestHandler for Quotes {
 	/// Get returns the quote stored for the given selector u32 or 404 (Not Found).
 	async fn get(store: Arc<RwLock<Store>>, _request: &Request<OwnedWriteHalf>, selector: Option<u32>) -> Result<String, HttpResponse> {
@@ -189,7 +186,6 @@ impl RequestHandler for Quotes {
 /// Handle ping requests on /api/ping
 struct Ping {}
 
-#[async_trait]
 impl RequestHandler for Ping {
 	async fn get(_store: Arc<RwLock<Store>>, _request: &Request<OwnedWriteHalf>, _selector: Option<u32>) -> Result<String, HttpResponse> {
 		Ok("pong".to_string())

--- a/tests/commons.rs
+++ b/tests/commons.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::io::Read;
 use std::convert::From;
+use std::future::Future;
 use tokio::io::AsyncWrite;
-use async_trait::async_trait;
 
 pub enum RecordType {
 	BeginRequest = 1,
@@ -53,16 +53,14 @@ pub fn create_record(request_type: RecordType, request_id: u8, padding: u8, data
 	record
 }
 
-#[async_trait]
 pub trait TestCase {
 	fn get_input() -> Mock;
 	fn get_output() -> Mock;
-	async fn processor<W: AsyncWrite + Unpin + Send>(request: Arc<Request<W>>) -> RequestResult;
+	fn processor<W: AsyncWrite + Unpin + Send>(request: Arc<Request<W>>) -> impl Future<Output = RequestResult> + Send;
 }
 
 pub struct TestParamsInOut {}
 
-#[async_trait]
 impl TestCase for TestParamsInOut {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -142,7 +140,6 @@ impl TestCase for TestParamsInOut {
 
 pub struct TestRoleAuthorizer {}
 
-#[async_trait]
 impl TestCase for TestRoleAuthorizer {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -175,7 +172,6 @@ impl TestCase for TestRoleAuthorizer {
 
 pub struct TestRoleFilter {}
 
-#[async_trait]
 impl TestCase for TestRoleFilter {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -219,7 +215,6 @@ impl TestCase for TestRoleFilter {
 
 pub struct TestAbortRequest {}
 
-#[async_trait]
 impl TestCase for TestAbortRequest {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -243,7 +238,6 @@ impl TestCase for TestAbortRequest {
 
 pub struct TestAbortContinue {}
 
-#[async_trait]
 impl TestCase for TestAbortContinue {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -279,7 +273,6 @@ impl TestCase for TestAbortContinue {
 
 pub struct TestUnknownRoleReturn {}
 
-#[async_trait]
 impl TestCase for TestUnknownRoleReturn {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -306,7 +299,6 @@ impl TestCase for TestUnknownRoleReturn {
 
 pub struct TestUnknownRoleRequest {}
 
-#[async_trait]
 impl TestCase for TestUnknownRoleRequest {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -331,7 +323,6 @@ impl TestCase for TestUnknownRoleRequest {
 
 pub struct TestUnknownRequestType {}
 
-#[async_trait]
 impl TestCase for TestUnknownRequestType {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -355,7 +346,6 @@ impl TestCase for TestUnknownRequestType {
 
 pub struct TestGetValues {}
 
-#[async_trait]
 impl TestCase for TestGetValues {
 	fn get_input() -> Mock {
 		Builder::new()
@@ -380,7 +370,6 @@ impl TestCase for TestGetValues {
 pub struct TestKeepConnection {
 }
 
-#[async_trait]
 impl TestCase for TestKeepConnection {
 	fn get_input() -> Mock {
 		Builder::new()


### PR DESCRIPTION
Since Rust 1.75.0, `async fn` can be used in traits.  This removes the dependency on the `async-trait` dependency, and fixes a slight error this proc-macro was hiding, replacing it with a normal function returning an `impl Future`.